### PR TITLE
refactor(init): Add response handlers module

### DIFF
--- a/doc/explain-it.txt
+++ b/doc/explain-it.txt
@@ -87,6 +87,17 @@ Creates a temporary file on the operating system
 
 ==============================================================================
 ------------------------------------------------------------------------------
+                                                           *M.notify_response()*
+                       `M.notify_response`({ai_response})
+response using notify
+Parameters~
+{ai_response} AIResponse
+Return~
+`(nil)`
+
+
+==============================================================================
+------------------------------------------------------------------------------
 Class~
 {AIResponse}
 Fields~

--- a/doc/tags
+++ b/doc/tags
@@ -15,6 +15,7 @@ M.get_visual_selection()	explain-it.txt	/*M.get_visual_selection()*
 M.make_system_call()	explain-it.txt	/*M.make_system_call()*
 M.make_system_call_with_retry()	explain-it.txt	/*M.make_system_call_with_retry()*
 M.make_temp_file()	explain-it.txt	/*M.make_temp_file()*
+M.notify_response()	explain-it.txt	/*M.notify_response()*
 M.options	explain-it.txt	/*M.options*
 M.parse_response()	explain-it.txt	/*M.parse_response()*
 M.setup()	explain-it.txt	/*M.setup()*

--- a/lua/explain-it/handlers/response.lua
+++ b/lua/explain-it/handlers/response.lua
@@ -1,0 +1,29 @@
+local notify = require "notify"
+
+local M = {}
+
+---Notifies response using notify
+---@param ai_response AIResponse
+---@return nil
+M.notify_response = function(ai_response)
+  if not ai_response then
+    return nil
+  end
+  local notification_template = [[
+  Question:
+  ##QUESTION##
+
+  Input:
+  ##INPUT##
+
+  Response:
+  ##RESPONSE##
+  ]]
+  local replaced_question = notification_template:gsub("##QUESTION##", ai_response.question)
+  local replaced_input = replaced_question:gsub("##INPUT##", ai_response.input)
+  local replaced_response = replaced_input:gsub("##RESPONSE##", ai_response.response)
+
+  notify(replaced_response)
+end
+
+return M

--- a/lua/explain-it/init.lua
+++ b/lua/explain-it/init.lua
@@ -1,8 +1,8 @@
 local buff = require "explain-it.util.buffer"
+local response_handler = require "explain-it.handlers.response"
 local escape = require "explain-it.util.escape"
 local chat_gpt = require "explain-it.services.chat-gpt"
 local D = require "explain-it.util.debug"
-local notify = require "notify"
 local ExplainIt = {}
 
 --- Sets up plugin with user-provided options
@@ -48,29 +48,15 @@ end
 ---@param opts any
 function ExplainIt.call_chat_gpt(opts)
   local custom_prompt = opts and opts.custom_prompt or nil
-  local response = {}
+  local ai_response = {}
   if opts.api_type == "completion" then
     D.log("ExplainIt.call_chat_gpt", "using completion")
-    response = chat_gpt.call_gpt(opts.text, custom_prompt, "command")
+    ai_response = chat_gpt.call_gpt(opts.text, custom_prompt, "command")
   else
     D.log("ExplainIt.call_chat_gpt", "using chat")
-    response = chat_gpt.call_gpt(opts.text, custom_prompt, "chat_command")
+    ai_response = chat_gpt.call_gpt(opts.text, custom_prompt, "chat_command")
   end
-  local notification_template = [[
-  Question:
-  ##QUESTION##
-
-  Input:
-  ##INPUT##
-
-  Response:
-  ##RESPONSE##
-  ]]
-  local replaced_question = notification_template:gsub("##QUESTION##", response.question)
-  local replaced_input = replaced_question:gsub("##INPUT##", response.input)
-  local replaced_response = replaced_input:gsub("##RESPONSE##", response.response)
-
-  notify(replaced_response)
+  response_handler.notify_response(ai_response)
 end
 
 _G.ExplainIt = ExplainIt

--- a/lua/tests/handlers/response_spec.lua
+++ b/lua/tests/handlers/response_spec.lua
@@ -1,0 +1,32 @@
+local stub = require "luassert.stub"
+local response_handler = require "explain-it.handlers.response"
+local notify = require "notify"
+describe("notify", function()
+  before_each(function()
+    stub(notify, "notify")
+  end)
+
+  it("should notify response", function()
+    local ai_response = {
+      question = "What is your name?",
+      input = "My name is John",
+      response = "Nice to meet you John",
+    }
+    local expected_notification = [[  Question:
+  What is your name?
+
+  Input:
+  My name is John
+
+  Response:
+  Nice to meet you John
+  ]]
+    response_handler.notify_response(ai_response)
+    assert.stub(notify.notify).was_called_with(expected_notification, nil, nil)
+  end)
+
+  it("should not notify response if ai_response is nil", function()
+    response_handler.notify_response(nil)
+    assert.stub(notify.notify).was_not_called()
+  end)
+end)

--- a/lua/tests/init_spec.lua
+++ b/lua/tests/init_spec.lua
@@ -6,6 +6,7 @@ local buff = require "explain-it.util.buffer"
 local escape = require "explain-it.util.escape"
 local chat_gpt = require "explain-it.services.chat-gpt"
 local notify = require "notify"
+local response_handler = require "explain-it.handlers.response"
 
 describe("ExplainIt", function()
   before_each(function()
@@ -13,6 +14,7 @@ describe("ExplainIt", function()
     stub(buff, "get_buffer_lines")
     stub(escape, "get_escaped_string")
     stub(ExplainIt, "call_chat_gpt")
+    stub(response_handler, "notify_response")
     stub(vim.ui, "input")
   end)
   after_each(function()
@@ -117,21 +119,13 @@ describe("call_chat_gpt", function()
   end)
 
   it("should call notify with the response from chat_gpt.call_gpt", function()
-    chat_gpt.call_gpt.returns {
+    local ai_response = {
       question = "some question",
       input = "some input",
       response = "some response",
     }
+    chat_gpt.call_gpt.returns(ai_response)
     ExplainIt.call_chat_gpt { api_type = "completion", text = "text" }
-    local expected = [[  Question:
-  some question
-
-  Input:
-  some input
-
-  Response:
-  some response
-  ]]
-    assert.stub(notify.notify).was_called_with(expected, nil, nil)
+    assert.stub(response_handler.notify_response).was_called_with(ai_response)
   end)
 end)


### PR DESCRIPTION
This adds a new module, `explain-it.handlers.response`, that will be used for handling various responses. For now, it simple handles an `ai_response` notification using `notify`. Soon this will also support:
* Writing to a temp buffer
* Appending to current buffer
* Writing to a temp file (moved from the `chat_gpt` service)