### PR TITLE
Fix newline splitting in response notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@
         -- Prints useful log messages
         debug = true,
         -- Customize notification window width
-        max_notification_width = 20,
+        max_notification_width = 200,
         -- Retry API calls
         max_retries = 3,
         -- Customize response text file persistence location
@@ -115,11 +115,17 @@
         split_responses = false,
         -- Set token limit to prioritize keeping costs low, or increasing quality/length of responses
         token_limit = 2000,
+        -- Per-filetype default prompt questions
+        default_prompts = {
+          ["markdown"] = "Answer this question:",
+          ["txt"] = "Explain this block of text:",
+          ["lua"] = "What does this code do?",
+          ["zsh"] = "Answer this question:",
+        },
       }
     end
   })
 ```
-
 </td>
 </tr>
 <tr>
@@ -147,6 +153,13 @@
           split_responses = false,
           -- Set token limit to prioritize keeping costs low, or increasing quality/length of responses
           token_limit = 2000,
+          -- Per-filetype default prompt questions
+          default_prompts = {
+            ["markdown"] = "Answer this question:",
+            ["txt"] = "Explain this block of text:",
+            ["lua"] = "What does this code do?",
+            ["zsh"] = "Answer this question:",
+          },
         }
       end
   },

--- a/doc/explain-it.txt
+++ b/doc/explain-it.txt
@@ -103,7 +103,7 @@ Class~
 Fields~
 {question} `(string)`
 {input} `(string)`
-{response} `(string|table)`
+{response} `(string)`
 
 ------------------------------------------------------------------------------
                                                             *completion_command*

--- a/docker/nvim/init.lua
+++ b/docker/nvim/init.lua
@@ -29,6 +29,13 @@ local plugins = {
         split_responses = true,
         -- Set token limit to prioritize keeping costs low, or increasing quality/length of responses
         token_limit = 2000,
+        -- Per-filetype default prompt questions
+        default_prompts = {
+          ["markdown"] = "Answer this question:",
+          ["txt"] = "Explain this block of text:",
+          ["lua"] = "What does this code do?",
+          ["zsh"] = "Answer this question:",
+        },
       }
     end,
   },

--- a/lua/explain-it/handlers/response.lua
+++ b/lua/explain-it/handlers/response.lua
@@ -1,3 +1,4 @@
+local strings = require "explain-it.util.strings"
 local notify = require "notify"
 
 local M = {}
@@ -19,9 +20,18 @@ M.notify_response = function(ai_response)
   Response:
   ##RESPONSE##
   ]]
-  local replaced_question = notification_template:gsub("##QUESTION##", ai_response.question)
-  local replaced_input = replaced_question:gsub("##INPUT##", ai_response.input)
-  local replaced_response = replaced_input:gsub("##RESPONSE##", ai_response.response)
+  local should_split = _G.ExplainIt.config.split_responses
+  local width = _G.ExplainIt.config.max_notification_width
+  local question = should_split and strings.truncate_string(ai_response.question, width)
+    or ai_response.question
+  local input = should_split and strings.truncate_string(ai_response.input, width)
+    or ai_response.input
+  local response = should_split and strings.format_string_with_line_breaks(ai_response.response)
+    or ai_response.response
+
+  local replaced_question = notification_template:gsub("##QUESTION##", question)
+  local replaced_input = replaced_question:gsub("##INPUT##", input)
+  local replaced_response = replaced_input:gsub("##RESPONSE##", response)
 
   notify(replaced_response)
 end

--- a/lua/explain-it/services/chat-gpt.lua
+++ b/lua/explain-it/services/chat-gpt.lua
@@ -84,7 +84,7 @@ M.get_question = function(question)
     local ft = M.get_filetype()
     question = _G.ExplainIt.config.default_prompts[ft]
     if not question then
-      question = "Explain this:"
+      question = "Answer this question:"
     end
   end
   return question

--- a/lua/explain-it/services/chat-gpt.lua
+++ b/lua/explain-it/services/chat-gpt.lua
@@ -8,7 +8,7 @@ local M = {}
 ---@class AIResponse
 ---@field question string
 ---@field input string
----@field response string|table
+---@field response string
 
 ---@alias completion_command string
 local completion_command = [[

--- a/lua/explain-it/util/strings.lua
+++ b/lua/explain-it/util/strings.lua
@@ -7,20 +7,27 @@ function M.format_string_with_line_breaks(str)
   local formattedStr = ""
   local lineLength = 0
   local words = {}
-  for word in str:gmatch "%S+" do
-    table.insert(words, word)
-  end
-  for _, word in ipairs(words) do
-    if lineLength + #word > _G.ExplainIt.config.max_notification_width then
-      formattedStr = formattedStr .. "\n" .. word
-      lineLength = #word
+  for line in str:gmatch("[^\r\n]+") do -- split string into lines
+    if #line <= _G.ExplainIt.config.max_notification_width then
+      formattedStr = formattedStr .. line .. "\n" -- preserve newline
+      lineLength = 0
     else
-      formattedStr = formattedStr .. " " .. word
-      lineLength = lineLength + #word + 1
+      for word in line:gmatch("%S+") do -- split line into words
+        if lineLength + #word > _G.ExplainIt.config.max_notification_width then
+          formattedStr = formattedStr .. "\n" .. word
+          lineLength = #word
+        else
+          formattedStr = formattedStr .. " " .. word
+          lineLength = lineLength + #word + 1
+        end
+      end
+      formattedStr = formattedStr .. "\n" -- preserve newline
+      lineLength = 0
     end
   end
-  local stripped, _ = string.gsub(formattedStr, "^%s", "")
-  return stripped
+  local stripped, _ = string.gsub(formattedStr, "^%s+", "") -- remove leading whitespace
+  local no_trailing_newline, _ = stripped:gsub("\n$", "") -- remove trailing newline
+  return no_trailing_newline
 end
 
 --- Takes a string as input and returns a truncated version of the string if it is longer than 77 characters. The truncated version includes an ellipsis ("...") at the end. If the string is 77 characters or shorter, the function simply returns the original string. The code also includes comments that describe the function's input and output parameters. Finally, the code returns the module "M".

--- a/lua/explain-it/util/strings.lua
+++ b/lua/explain-it/util/strings.lua
@@ -7,12 +7,12 @@ function M.format_string_with_line_breaks(str)
   local formattedStr = ""
   local lineLength = 0
   local words = {}
-  for line in str:gmatch("[^\r\n]+") do -- split string into lines
+  for line in str:gmatch "[^\r\n]+" do -- split string into lines
     if #line <= _G.ExplainIt.config.max_notification_width then
       formattedStr = formattedStr .. line .. "\n" -- preserve newline
       lineLength = 0
     else
-      for word in line:gmatch("%S+") do -- split line into words
+      for word in line:gmatch "%S+" do -- split line into words
         if lineLength + #word > _G.ExplainIt.config.max_notification_width then
           formattedStr = formattedStr .. "\n" .. word
           lineLength = #word

--- a/lua/tests/handlers/response_spec.lua
+++ b/lua/tests/handlers/response_spec.lua
@@ -4,6 +4,9 @@ local notify = require "notify"
 describe("notify", function()
   before_each(function()
     stub(notify, "notify")
+    require("explain-it").setup {
+      token_limit = 2000,
+    }
   end)
 
   it("should notify response", function()


### PR DESCRIPTION
## 📃 Summary
This preserves newlines in response notifications. Prior to this, notifications would split strings correctly that exceeded the `max_notification_width`, but if they didn't, it would insert spaces instead of newlines at line breaks.
<!-- Provide some context about the pull request, it makes the review easier. -->

## 📸 Preview
![2023-07-05_07-02](https://github.com/tdfacer/explain-it.nvim/assets/17553916/986805c9-f406-49bf-a162-3270bbdf6f71)

<!-- If there's a visual impact to your change, please provide a screenshot. You can directly upload it to GitHub by dragging in this text area. -->
